### PR TITLE
CurrencyField should not contain NumberStyle field

### DIFF
--- a/wallet/models.py
+++ b/wallet/models.py
@@ -81,7 +81,7 @@ class NumberField(Field):
         return self.__dict__
 
 
-class CurrencyField(NumberField):
+class CurrencyField(Field):
 
     def __init__(self, key, value, label='', currencyCode=''):
         super(CurrencyField, self).__init__(key, value, label)


### PR DESCRIPTION
Apple mandates that you can only have either a numberStyle key or a currencyCode key per field.

https://developer.apple.com/library/archive/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/FieldDictionary.html#//apple_ref/doc/uid/TP40012026-CH4-SW1